### PR TITLE
feat: add TypeScript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Then generate your new project:
 yo node-next
 ```
 
+You can generate project using TypeScript:
+
+```bash
+yo node-next:ts-app
+```
+
 ## Getting To Know Yeoman
 
  * Yeoman has a heart of gold.

--- a/__tests__/ts-app.js
+++ b/__tests__/ts-app.js
@@ -1,0 +1,134 @@
+'use strict';
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const generatorPath = path.join(__dirname, '../generators/ts-app');
+
+describe('generator-node-next:ts-app', () => {
+  it('creates files', () => {
+    return helpers
+      .run(generatorPath)
+      .withPrompts({})
+      .then(function() {
+        assert.file([
+          'package.json',
+          'backpack.config.js',
+          '.gitignore',
+          'README.md',
+          'tslint.json',
+          '.editorconfig',
+          '.travis.yml',
+          'src/index.ts',
+          'src/sum.ts',
+          'tsconfig.json'
+        ]);
+      });
+  });
+
+  it('creates .travis.yml only if Travis CI is enabled', () => {
+    return helpers
+      .run(generatorPath)
+      .withPrompts({ travis: false })
+      .then(function() {
+        assert.noFile(['.travis.yml']);
+      });
+  });
+
+  it('creates Dockerfile and .dockerignore only if Docker deployment is enabled', () => {
+    return helpers
+      .run(generatorPath)
+      .withPrompts({ docker: false })
+      .then(function() {
+        assert.noFile(['Dockerfile', '.dockerignore']);
+      });
+  });
+
+  it('creates valid dependencies and scripts in package.json if unit testing with Jest is enabled', () => {
+    return helpers
+      .run(generatorPath)
+      .withPrompts({ unit: true, runner: 'jest' })
+      .then(function() {
+        assert.fileContent('package.json', /"test:unit": "jest"/);
+        assert.fileContent('package.json', /yarn run test:unit/);
+        assert.fileContent('package.json', /"jest"/);
+      });
+  });
+
+  it('creates valid dependencies and scripts in package.json if unit testing with AVA is enabled', () => {
+    return helpers
+      .run(generatorPath)
+      .withPrompts({ unit: true, runner: 'ava' })
+      .then(function() {
+        assert.fileContent(
+          'package.json',
+          '"test:unit": "tsc --lib es2015 test/*.ts && ava && rimraf test/*.js"'
+        );
+        assert.fileContent('package.json', /yarn run test:unit/);
+        assert.fileContent('package.json', /"ava"/);
+        assert.fileContent('package.json', /"rimraf"/);
+      });
+  });
+  it('creates package.json with valid name, description and author', () => {
+    return helpers
+      .run(generatorPath)
+      .withPrompts({
+        name: 'test',
+        descr: 'lorem ipsum dolor sit amet',
+        author: 'Jonh Doe'
+      })
+      .then(function() {
+        assert.fileContent('package.json', /"name": "test"/);
+        assert.fileContent('package.json', /"description": "lorem ipsum dolor sit amet"/);
+        assert.fileContent('package.json', /"author": "Jonh Doe"/);
+      });
+  });
+
+  it('creates README.md with valid name, description, author and badges', () => {
+    return helpers
+      .run(generatorPath)
+      .withPrompts({
+        name: 'test',
+        descr: 'lorem ipsum dolor sit amet',
+        author: 'doe'
+      })
+      .then(function() {
+        assert.fileContent('README.md', /# test/, /<%= lorem ipsum dolor sit amet %>/);
+
+        assert.fileContent('README.md', /badge.fury.io\/js\/test.svg/);
+        assert.fileContent('README.md', /npmjs.org\/package\/test/);
+        assert.fileContent(
+          'README.md',
+          /https:\/\/travis-ci.org\/doe\/test.svg\?branch=master/
+        );
+        assert.fileContent('README.md', /https:\/\/travis-ci.org\/doe\/test/);
+        assert.fileContent(
+          'README.md',
+          /https:\/\/david-dm.org\/doe\/test.svg\?theme=shields.io/
+        );
+        assert.fileContent('README.md', /https:\/\/david-dm.org\/doe\/test/);
+        assert.fileContent(
+          'README.md',
+          /https:\/\/coveralls.io\/repos\/doe\/test\/badge.svg/
+        );
+        assert.fileContent('README.md', /https:\/\/coveralls.io\/r\/doe\/test/);
+      });
+  });
+
+  it('creates Jest test spec and config if unit testing with Jest is enabled', () => {
+    return helpers
+      .run(generatorPath)
+      .withPrompts({ unit: true, runner: 'jest' })
+      .then(function() {
+        assert.file(['__tests__/sum.spec.ts']);
+        assert.file(['jest.config.js']);
+      });
+  });
+  it('creates AVA test spec if unit testing with AVA is enabled', () => {
+    return helpers
+      .run(generatorPath)
+      .withPrompts({ unit: true, runner: 'ava' })
+      .then(function() {
+        assert.file(['test/sum.test.ts']);
+      });
+  });
+});

--- a/generators/ts-app/index.js
+++ b/generators/ts-app/index.js
@@ -1,0 +1,140 @@
+'use strict';
+const Generator = require('yeoman-generator');
+const chalk = require('chalk');
+const yosay = require('yosay');
+
+module.exports = class extends Generator {
+  async prompting() {
+    // Have Yeoman greet the user.
+    this.log(
+      yosay(
+        'Welcome to the prime ' +
+          chalk.red('generator-node-next') +
+          ' generator! Answer some questions and your ' +
+          chalk.green('awesome') +
+          ' app will be created!'
+      )
+    );
+
+    const prompts = [
+      {
+        type: 'input',
+        name: 'name',
+        message: 'Name of your app:',
+        default: 'my-awesome-app'
+      },
+      {
+        type: 'input',
+        name: 'descr',
+        message: 'Description of your app:',
+        default: 'Hello, World!'
+      },
+      {
+        type: 'input',
+        name: 'author',
+        message: 'Author (your nickname on github):',
+        default: 'sh7dm'
+      },
+      {
+        type: 'list',
+        name: 'packageManager',
+        message: 'Package manager to install dependencies with:',
+        default: 'yarn',
+        choices: ['yarn', 'npm']
+      },
+      {
+        type: 'confirm',
+        name: 'unit',
+        message: 'Would you like to enable unit tests?',
+        default: true
+      },
+      {
+        type: 'confirm',
+        name: 'docker',
+        message: 'Would you like to enable Docker deployment?',
+        default: true
+      },
+      {
+        type: 'confirm',
+        name: 'travis',
+        message: 'Would you like to enable Travis CI?',
+        default: true
+      }
+    ];
+
+    let props = await this.prompt(prompts);
+
+    if (props.unit) {
+      props.runner = (await this.prompt([
+        {
+          type: 'list',
+          name: 'runner',
+          message: 'Test runner to use:',
+          choices: ['jest', 'ava']
+        }
+      ])).runner;
+    }
+
+    this.props = props;
+  }
+
+  writing() {
+    let ins = ['package.json.ejs', '.gitignore.ejs', 'README.md.ejs'];
+    let outs = ['package.json', '.gitignore', 'README.md'];
+    ins.forEach((inp, i) => {
+      this.fs.copyTpl(this.templatePath(inp), this.destinationPath(outs[i]), this.props);
+    });
+
+    this.fs.copy(
+      this.templatePath('.editorconfig'),
+      this.destinationPath('.editorconfig')
+    );
+    this.fs.copy(this.templatePath('src'), this.destinationPath('src'));
+    this.fs.copy(
+      this.templatePath('tsconfig.json'),
+      this.destinationPath('tsconfig.json')
+    );
+    this.fs.copy(this.templatePath('tslint.json'), this.destinationPath('tslint.json'));
+    this.fs.copy(
+      this.templatePath('backpack.config.js'),
+      this.destinationPath('backpack.config.js')
+    );
+
+    if (this.props.unit && this.props.runner === 'jest') {
+      this.fs.copy(this.templatePath('__tests__'), this.destinationPath('__tests__'));
+      this.fs.copy(
+        this.templatePath('jest.config.js'),
+        this.destinationPath('jest.config.js')
+      );
+    } else if (this.props.unit && this.props.runner === 'ava') {
+      this.fs.copy(this.templatePath('test'), this.destinationPath('test'));
+    }
+
+    if (this.props.docker) {
+      this.fs.copy(this.templatePath('Dockerfile'), this.destinationPath('Dockerfile'));
+      this.fs.copy(
+        this.templatePath('.dockerignore'),
+        this.destinationPath('.dockerignore')
+      );
+    }
+    if (this.props.travis) {
+      this.fs.copy(this.templatePath('.travis.yml'), this.destinationPath('.travis.yml'));
+    }
+  }
+
+  install() {
+    if (this.props.packageManager === 'yarn') {
+      this.installDependencies({
+        npm: false,
+        bower: false,
+        yarn: true
+      }); // Use yarn
+    } else {
+      this.installDependencies({
+        npm: true,
+        bower: false,
+        yarn: false
+      }); // Use npm
+    }
+  }
+};

--- a/generators/ts-app/templates/.dockerignore
+++ b/generators/ts-app/templates/.dockerignore
@@ -1,0 +1,16 @@
+# Logs
+logs
+*.log
+
+# Coverage directory
+**/coverage
+
+# Build output
+build
+
+# Dependency directory
+# https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
+node_modules
+
+__tests__
+test

--- a/generators/ts-app/templates/.editorconfig
+++ b/generators/ts-app/templates/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/generators/ts-app/templates/.gitignore.ejs
+++ b/generators/ts-app/templates/.gitignore.ejs
@@ -1,0 +1,6 @@
+node_modules
+build
+<% if (unit) { %>**/coverage<% } %>
+logs
+*.log
+**/coverage

--- a/generators/ts-app/templates/.travis.yml
+++ b/generators/ts-app/templates/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - v10
+  - v9
+  - v8
+  - v6
+install:
+  yarn
+after_script: cat ./coverage/lcov.info | coveralls

--- a/generators/ts-app/templates/Dockerfile
+++ b/generators/ts-app/templates/Dockerfile
@@ -1,0 +1,9 @@
+FROM node
+
+COPY . /app
+WORKDIR /app
+
+RUN npm i
+RUN npm run build
+
+ENTRYPOINT [ "node", "build/main" ]

--- a/generators/ts-app/templates/README.md.ejs
+++ b/generators/ts-app/templates/README.md.ejs
@@ -1,0 +1,14 @@
+# <%= name %>[![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage percentage][coveralls-image]][coveralls-url]
+> <%= descr %>
+
+[![forthebadge](https://forthebadge.com/images/badges/built-with-love.svg)](https://forthebadge.com)
+
+<!--- If badges aren't working, fix links below --->
+[npm-image]: https://badge.fury.io/js/<%= name %>.svg
+[npm-url]: https://npmjs.org/package/<%= name %>
+[travis-image]: https://travis-ci.org/<%= author %>/<%= name %>.svg?branch=master
+[travis-url]: https://travis-ci.org/<%= author %>/<%= name %>
+[daviddm-image]: https://david-dm.org/<%= author %>/<%= name %>.svg?theme=shields.io
+[daviddm-url]: https://david-dm.org/<%= author %>/<%= name %>
+[coveralls-image]: https://coveralls.io/repos/<%= author %>/<%= name %>/badge.svg
+[coveralls-url]: https://coveralls.io/r/<%= author %>/<%= name %>

--- a/generators/ts-app/templates/__tests__/sum.spec.ts
+++ b/generators/ts-app/templates/__tests__/sum.spec.ts
@@ -1,0 +1,7 @@
+import sum from '../src/sum';
+
+describe('sum', () => {
+  it('should 2 + 2 = 4', () => {
+    expect(sum(2, 2)).toEqual(4);
+  });
+});

--- a/generators/ts-app/templates/backpack.config.js
+++ b/generators/ts-app/templates/backpack.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  webpack: (config, options, webpack) => {
+    config.entry.main = [
+      './src/index.ts'
+    ]
+
+    config.resolve = {
+      extensions: [".ts", ".js", ".json"]
+    };
+
+    config.module.rules.push(
+      {
+        test: /\.ts$/,
+        loader: 'awesome-typescript-loader'
+      }
+    );
+
+    return config
+  }
+}

--- a/generators/ts-app/templates/jest.config.js
+++ b/generators/ts-app/templates/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/generators/ts-app/templates/package.json.ejs
+++ b/generators/ts-app/templates/package.json.ejs
@@ -1,0 +1,40 @@
+{
+	"name": "<%= name %>",
+	"version": "0.0.0",
+	"description": "<%= descr %>",
+	"main": "src/index.js",
+	"scripts": {
+		"dev": "backpack",
+    "test:lint": "tslint -c tslint.json src/**/*.ts",
+    "test:safety": "snyk test",
+		<% if (unit) { %>
+			<% if (runner == "jest") { %>
+		    "test:unit": "jest",
+			<% } else { %>
+        "test:unit": "tsc --lib es2015 test/*.ts && ava && rimraf test/*.js",
+		  <% } %>
+		<% } %>
+    "test": "yarn run test:lint; yarn run test:safety; <% if (unit) { %>yarn run test:unit <% } %>",
+    "build": "backpack build",
+    "prepublish": "yarn run test"
+	},
+	"author": "<%= author %>",
+  "license": "MIT",
+	"devDependencies": {
+    <% if (unit && runner == "ava") { %>
+      "ava": "^0.25.0",
+      "rimraf": "^2.6.2",
+    <% } %>
+		"awesome-typescript-loader": "^5.2.1",
+		"backpack-core": "^0.5.0",
+    <% if (unit && runner == "jest") { %>
+      "jest": "^23.x",
+      "@types/jest": "^23.x",
+      "ts-jest": "^23.10.5",
+    <% } %>
+    "typescript": "^3.1.6",
+    "tslint": "^5.8.0",
+    "tslint-config-prettier": "^1.13.0",
+		"snyk": "^1.69.7"
+  }
+}

--- a/generators/ts-app/templates/src/index.ts
+++ b/generators/ts-app/templates/src/index.ts
@@ -1,0 +1,3 @@
+import sum from './sum';
+
+console.log(sum(2, 2));

--- a/generators/ts-app/templates/src/sum.ts
+++ b/generators/ts-app/templates/src/sum.ts
@@ -1,0 +1,3 @@
+export default function (a: number, b: number): number {
+  return a + b;
+}

--- a/generators/ts-app/templates/test/sum.test.ts
+++ b/generators/ts-app/templates/test/sum.test.ts
@@ -1,0 +1,6 @@
+import test from 'ava';
+import sum from '../src/sum';
+
+test('2 + 2 = 4', async t => {
+  t.is(sum(2, 2), 4);
+});

--- a/generators/ts-app/templates/tsconfig.json
+++ b/generators/ts-app/templates/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "skipLibCheck": true,
+    "target": "es5",
+    "removeComments": true,
+    "sourceMap": true,
+    "declaration": true,
+    "outDir": "dist",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "lib": ["es5", "es6", "es7", "dom", "dom.iterable"],
+    "jsx": "react",
+    "rootDirs": ["src", "test"],
+    "strict": true
+  },
+  "include": [
+    "src/**/*",
+    "__tests__/**/*",
+    "declarations.d.ts",
+    "jest.config.js"
+  ],
+  "exclude": ["dist", "examples", "node_modules"],
+  "types": ["node"],
+  "typeRoots": ["node_modules/@types"]
+}

--- a/generators/ts-app/templates/tslint.json
+++ b/generators/ts-app/templates/tslint.json
@@ -1,0 +1,19 @@
+{
+  "extends": ["tslint:latest", "tslint-config-prettier"],
+  "rules": {
+    "max-line-length": {
+      "options": [120]
+    },
+    "new-parens": true,
+    "no-arg": true,
+    "no-bitwise": true,
+    "no-conditional-assignment": true,
+    "no-consecutive-blank-lines": false,
+    "no-console": false
+  },
+  "jsRules": {
+    "max-line-length": {
+      "options": [120]
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-node-next",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
add `ts-app` generator

## TODO
- [x] Add basic generator
- [x] Add Jest support
- [x] Add AVA support
- [x] Add tests for `ts-app` generator:
  - [x] Creates source code
  - [x] Creates `Dockerfile` and `.dockerignore` if Docker is enabled
  - [x] Creates `.travis.yml` if Travis CI is enabled
  - [x] Creates `.editorconfig`, valid `.gitignore`, `backpack.config.js`, valid `package.json` and `README.md`, `tsconfig.json`, `tslint.json`
  - [x] Creates AVA test files and valid AVA config if AVA is enabled
  - [x] Creates Jest test files and valid Jest config if Jest is enabled
- [x] Add guide for using TypeScript